### PR TITLE
Refactor filter styling

### DIFF
--- a/app/views/shared/_apply-filters-button.html.erb
+++ b/app/views/shared/_apply-filters-button.html.erb
@@ -1,0 +1,1 @@
+<%= button_tag "Apply filters", type: :submit, name: "apply", class: "govuk-button govuk-button--secondary", "data-cy": "data-service-apply-filters-button" %>

--- a/app/views/shared/_clear-filters-button.html.erb
+++ b/app/views/shared/_clear-filters-button.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Clear filters", data_services_path(query: params[:query]), class: "govuk-link govuk-link--no-visited-state", "data-cy": "data-service-clear-filters-button" %>

--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -1,23 +1,24 @@
 <%= form_with url: data_services_path, method: :get, "data-cy": "data-service-search-form", class: "govuk-form-group" do |form|  %>
+  <h1 class="govuk-heading-m">
+    Filter by topic and organisation
+  </h1>
+  <div class="govuk-button-group">
+    <%= render 'shared/apply-filters-button' %>
+    <% if params[:filters].present? %>
+      <%= render 'shared/clear-filters-button' %>
+    <%end%>
+  </div>
   <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-      <h2 class="govuk-fieldset__heading">
-        Filter by topic and organisation
-      </h2>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+    Organisations
     </legend>
-    <div class="govuk-button-group">
-    <%= button_tag "Apply filters", type: :submit, name: "apply", class: "govuk-button govuk-button--secondary", "data-cy": "data-service-apply-filters-button" %>
-    <%= link_to "Clear filters", data_services_path(query: params[:query]), class: "govuk-button govuk-button--secondary", "data-cy": "data-service-clear-filters-button" %>
-        <div id="topic-hint" class="govuk-hint">
-        Organisations
-        </div>
-        <div class="govuk-checkboxes--small" data-module="govuk-checkboxes">
-        <% @organisations_checkbox_list.each do |organisation| %>
+    <div class="govuk-checkboxes--small" data-module="govuk-checkboxes">
+      <% @organisations_checkbox_list.each do |organisation| %>
         <div class="govuk-checkboxes__item" data-cy="organisation-<%= organisation.name %>-checkbox">
-        <%= form.check_box :filters, {:multiple => true, class: "govuk-checkboxes__input", "data-cy": "organisation-#{organisation.name}-checkbox-input", checked: params[:filters]&.include?(organisation.id) }, organisation.id, nil %>
-          <%= form.label :filters, "#{organisation.name}", "data-cy": "data-service-search-label", class: "govuk-label govuk-checkboxes__label" %>
+          <%= form.check_box :filters, {:multiple => true, class: "govuk-checkboxes__input", "data-cy": "organisation-#{organisation.name}-checkbox-input", checked: params[:filters]&.include?(organisation.id) }, organisation.id, nil %>
+          <%= form.label :filters, "#{organisation.name}", for: "filters_#{organisation.id}", "data-cy": "data-service-search-label", class: "govuk-label govuk-checkboxes__label" %>
         </div> 
-        <%end%>
+      <%end%>
     </div>
   </fieldset>
 <%end%>

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -12,19 +12,21 @@ RSpec.describe 'Filters' do
       create(:data_service, name: 'Test Data Service', organisation_id: organisation_test.id)
     end
 
-    it 'User loads the page with all services' do
+    it 'User loads the page with all services but the clear filters button is not visible' do
       visit '/'
       expect(page).to have_selector('div.govuk-checkboxes--small div', count: 6)
+      expect(page).to_not have_selector('a.govuk-link.govuk-link--no-visited-state[data-cy="data-service-clear-filters-button"]')
     end
 
-    it 'Shows only data from selected organisation' do
+    it 'User loads page, filters by organisation, the results are displayed and clear filters button becomes visible' do
       visit '/'
       check("filters_#{organisation_test.id}")
       click_button 'Apply filters'
       expect(page).to have_selector('ul.data-services li', count: 1)
+      expect(page).to have_selector('a.govuk-link.govuk-link--no-visited-state[data-cy="data-service-clear-filters-button"]', count: 1)
     end
 
-    it 'Clears filters' do
+    it 'User loads page, filters by organisation and then removes the filters which then displays all services' do
       visit '/'
       check("filters_#{organisation_test.id}")
       click_button 'Apply filters'

--- a/spec/features/filter_spec.rb
+++ b/spec/features/filter_spec.rb
@@ -15,15 +15,15 @@ RSpec.describe 'Filters' do
     it 'User loads the page with all services but the clear filters button is not visible' do
       visit '/'
       expect(page).to have_selector('div.govuk-checkboxes--small div', count: 6)
-      expect(page).to_not have_selector('a.govuk-link.govuk-link--no-visited-state[data-cy="data-service-clear-filters-button"]')
+      expect(page).not_to have_selector('a.govuk-link.govuk-link--no-visited-state')
     end
 
-    it 'User loads page, filters by organisation, the results are displayed and clear filters button becomes visible' do
+    it 'User loads page, filters by organisation, the results are displayed, clear button becomes visible' do
       visit '/'
       check("filters_#{organisation_test.id}")
       click_button 'Apply filters'
       expect(page).to have_selector('ul.data-services li', count: 1)
-      expect(page).to have_selector('a.govuk-link.govuk-link--no-visited-state[data-cy="data-service-clear-filters-button"]', count: 1)
+      expect(page).to have_selector('a.govuk-link.govuk-link--no-visited-state')
     end
 
     it 'User loads page, filters by organisation and then removes the filters which then displays all services' do


### PR DESCRIPTION
- Labels in checkboxes now clickable
- Clear + Apply Filters buttons moved into separate partials
- Clear filters button conditionally visible depending on filter selection
- Minor style changes to match prototype styling