### PR TITLE
Empty Parameter URL Fixes

### DIFF
--- a/app/views/data_services/index.html.erb
+++ b/app/views/data_services/index.html.erb
@@ -6,7 +6,7 @@
       <%= form.text_field :query, class: "govuk-input", value: params[:query], "data-cy": "data-service-search-input" %>
     </div>
     <div class="govuk-grid-column-one-third">
-      <%= form.submit "Search", class: "govuk-button", "data-cy": "data-service-search-button" %>
+      <%= form.submit "Search", name: nil, class: "govuk-button", "data-cy": "data-service-search-button" %>
     </div>
   </div>
   <div class="govuk-grid-row">

--- a/app/views/shared/_apply-filters-button.html.erb
+++ b/app/views/shared/_apply-filters-button.html.erb
@@ -1,1 +1,1 @@
-<%= button_tag "Apply filters", type: :submit, name: "apply", class: "govuk-button govuk-button--secondary", "data-cy": "data-service-apply-filters-button" %>
+<%= button_tag "Apply filters", type: :submit, name: nil, class: "govuk-button govuk-button--secondary", "data-cy": "data-service-apply-filters-button" %>

--- a/app/views/shared/_clear-filters-button.html.erb
+++ b/app/views/shared/_clear-filters-button.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "Clear filters", data_services_path(query: params[:query]), class: "govuk-link govuk-link--no-visited-state", "data-cy": "data-service-clear-filters-button" %>
+<%= link_to "Clear filters", data_services_path({query: params[:query].presence}.compact), class: "govuk-link govuk-link--no-visited-state", "data-cy": "data-service-clear-filters-button" %>


### PR DESCRIPTION
- Change names of buttons to nil to stop appearing in URL.
- Check query params for presence upon resetting the filters.