### PR TITLE
Set ID of search input component

### DIFF
--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -4,12 +4,6 @@
     inline_label: false,
     label_text: "Search the Data Catalogue",
     value: params[:query],
-    button_classes: "govuk-button",
-    label_classes: "govuk-label",
-    input_classes: "govuk-input",
-    form_classes: "govuk-form-group",
-    label_html: { "data-cy": "data-service-search-label" },
-    input_html: { "data-cy": "data-service-search-input" },
-    button_html: { "data-cy": "data-service-search-button" }
+    id: "data-service-search-input"
   } %>
 </div>


### PR DESCRIPTION
Set ID of search component to "data-service-search-input" to enable testing.

_I found that we are unable to target specific elements that are generated by the component but the overall ID targets just the input box. This will enable testers to isolate the input ID to perform tests._