### PR TITLE
WIP - Update services when fetching

### DIFF
--- a/spec/fixtures/source.json
+++ b/spec/fixtures/source.json
@@ -1,0 +1,16 @@
+{
+  "api-version": "api.gov.uk/v1alpha",
+  "apis": [
+    {
+      "api-version": "api.gov.uk/v1alpha",
+      "data": {
+        "name": "Food Alerts",
+        "description": "Description",
+        "url": "https://data.food.gov.uk/food-alerts",
+        "contact": "data@food.gov.uk",
+        "organisation": "Food Standards Agency",
+        "documentation-url": "https://data.food.gov.uk/food-alerts/ui/reference"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/source_updated.json
+++ b/spec/fixtures/source_updated.json
@@ -1,0 +1,16 @@
+{
+  "api-version": "api.gov.uk/v1alpha",
+  "apis": [
+    {
+      "api-version": "api.gov.uk/v1alpha",
+      "data": {
+        "name": "Food Alerts",
+        "description": "Description updated",
+        "url": "https://data.food.gov.uk/food-alerts",
+        "contact": "data@food.gov.uk",
+        "organisation": "Food Standards Agency",
+        "documentation-url": "https://data.food.gov.uk/food-alerts/ui/reference"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added a test to check whether a service gets updated if its description changes in the source we pull from. It's currently failing because we haven't implemented updating a resource yet.

Given that we use the name, url and organisation name to identify a service, we should only update the description, contact and documentation url fields.