### PR TITLE
Pagination bugfix

### DIFF
--- a/app/views/data_services/_data_service.html.erb
+++ b/app/views/data_services/_data_service.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
     <%= link_to data_service.name, data_service_path(data_service), "data-cy": "data-service-#{data_service.name}-link", class: "govuk-link" %>
   </h2>
-  <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1" data-cy="data-service-<%= data_service.organisation.name %>organisation-name"><%= data_service.organisation.name %></p>
+  <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1" data-cy="data-service-<%= data_service.organisation&.name %>organisation-name"><%= data_service.organisation&.name %></p>
   <p data-cy="data-service-<%= data_service.name %>-description"><%= data_service.description %></p>
   <hr>
 </li>

--- a/app/views/data_services/_data_service.html.erb
+++ b/app/views/data_services/_data_service.html.erb
@@ -1,8 +1,8 @@
 <li>
   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
-    <%= link_to data_service.name, data_service_path(data_service), "data-cy": "data-service-#{data_service.name}-link", class: "govuk-link" %>
+    <%= link_to data_service&.name, data_service_path(data_service), "data-cy": "data-service-#{data_service&.name}-link", class: "govuk-link" %>
   </h2>
-  <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1" data-cy="data-service-<%= data_service.organisation&.name %>organisation-name"><%= data_service.organisation&.name %></p>
-  <p data-cy="data-service-<%= data_service.name %>-description"><%= data_service.description %></p>
+  <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1" data-cy="data-service-<%= data_service.organisation&.name %>organisation-name"><%= data_service&.organisation&.name %></p>
+  <p data-cy="data-service-<%= data_service&.name %>-description"><%= data_service&.description %></p>
   <hr>
 </li>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -12,7 +12,7 @@
 # Instance variables
 # See https://ddnexus.github.io/pagy/docs/api/pagy#instance-variables
 # Pagy::DEFAULT[:page]   = 1                                  # default
-Pagy::DEFAULT[:items] = 20 # default
+Pagy::DEFAULT[:items] = 30 # default
 # Pagy::DEFAULT[:outset] = 0                                  # default
 
 # Other Variables

--- a/spec/features/pagination_spec.rb
+++ b/spec/features/pagination_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Pagination' do
 
     before do
       page.driver.browser.authorize ENV.fetch('HTTP_USERNAME'), ENV.fetch('HTTP_PASSWORD')
-      create_list(:data_service, 21)
+      create_list(:data_service, 31)
       create(:data_service, name: 'Test Data Service', organisation_id: organisation_test.id)
       visit '/data_services'
     end
@@ -41,29 +41,29 @@ RSpec.describe 'Pagination' do
     end
 
     it 'shows correct results at the top of the page' do
-      expect(page).to have_content '22 results'
+      expect(page).to have_content '32 results'
     end
 
     it 'shows correct results at the bottom of the page' do
-      expect(page).to have_content '1 to 20 of 22 results'
+      expect(page).to have_content '1 to 30 of 32 results'
     end
 
     it 'clicks next link' do
       click_link 'Next'
-      expect(page).to have_content 'Showing 21 to 22'
+      expect(page).to have_content 'Showing 31 to 32'
       click_link 'Previous'
-      expect(page).to have_content 'Showing 1 to 20'
+      expect(page).to have_content 'Showing 1 to 30'
     end
 
     it 'navigates using number links' do
       click_link '2'
-      expect(page).to have_content 'Showing 21 to 22'
+      expect(page).to have_content 'Showing 31 to 32'
       click_link '1'
-      expect(page).to have_content 'Showing 1 to 20'
+      expect(page).to have_content 'Showing 1 to 30'
     end
   end
 
-  context 'when results are under 20 there should be no pagination' do
+  context 'when results are under 30 there should be no pagination' do
     let(:organisation_test) { create(:organisation, name: 'Test Organisation') }
 
     before do


### PR DESCRIPTION
- Use safe navigation operator `&.` for incomplete records
- 30 records per page instead of 20
- Fix tests to accommodate 30 records per page instead of 20 