### PR TITLE
Update API & handle some error cases

### DIFF
--- a/app/controllers/api/v1/data_services_controller.rb
+++ b/app/controllers/api/v1/data_services_controller.rb
@@ -9,7 +9,7 @@ module Api
       def create
         data_service_form = DataServiceForm.new(data_service_params)
         if data_service_form.submit
-          render json: { data_service: data_service_form.data_service }, status: :created
+          render json: { data_service: { id: data_service_form.data_service.id } }, status: :created
         else
           render json: { errors: data_service_form.errors }, status: :unprocessable_entity
         end

--- a/app/controllers/api/v1/data_services_controller.rb
+++ b/app/controllers/api/v1/data_services_controller.rb
@@ -21,7 +21,11 @@ module Api
       private
 
       def data_service_params
-        params.require(:data_service).permit!
+        params.require(:data_service).permit(:endpoint_url, :endpoint_description, :serves_data, :service_type,
+                                                         :status, :identifier, :title, :description, :keywords, :themes,
+                                                         :licence, :version, :contact_name, :contact_email, :alternative_titles,
+                                                         :access_rights, :security_classification, :issued, :modified, :creators,
+                                                         :publisher, :related_data_resources, :summary, :created)
       end
 
       def handle_bad_request(exception)

--- a/app/controllers/api/v1/data_services_controller.rb
+++ b/app/controllers/api/v1/data_services_controller.rb
@@ -6,6 +6,9 @@ module Api
       wrap_parameters format: [:json]
       protect_from_forgery with: :null_session
 
+      rescue_from ActionController::ParameterMissing, with: :handle_bad_request
+      rescue_from ActionDispatch::Http::Parameters::ParseError, with: :handle_bad_request
+
       def create
         data_service_form = DataServiceForm.new(data_service_params)
         if data_service_form.submit
@@ -15,10 +18,14 @@ module Api
         end
       end
 
-      protected
+      private
 
       def data_service_params
         params.require(:data_service).permit!
+      end
+
+      def handle_bad_request(exception)
+        render json: { error: exception.message }, status: :bad_request
       end
     end
   end

--- a/app/controllers/api/v1/data_services_controller.rb
+++ b/app/controllers/api/v1/data_services_controller.rb
@@ -22,10 +22,10 @@ module Api
 
       def data_service_params
         params.require(:data_service).permit(:endpoint_url, :endpoint_description, :serves_data, :service_type,
-                                                         :status, :identifier, :title, :description, :keywords, :themes,
-                                                         :licence, :version, :contact_name, :contact_email, :alternative_titles,
-                                                         :access_rights, :security_classification, :issued, :modified, :creators,
-                                                         :publisher, :related_data_resources, :summary, :created)
+                                             :status, :identifier, :title, :description, :licence, :version,
+                                             :contact_name, :contact_email, :access_rights, :security_classification,
+                                             :issued, :modified, :created, :publisher, :summary, alternative_titles: [],
+                                             creators: [], keywords: [], related_data_resources: [], themes: [])
       end
 
       def handle_bad_request(exception)

--- a/app/controllers/api/v1/data_services_controller.rb
+++ b/app/controllers/api/v1/data_services_controller.rb
@@ -22,10 +22,11 @@ module Api
 
       def data_service_params
         params.require(:data_service).permit(:endpoint_url, :endpoint_description, :serves_data, :service_type,
-                                             :status, :identifier, :title, :description, :licence, :version,
+                                             :service_status, :identifier, :title, :description, :licence, :version,
                                              :contact_name, :contact_email, :access_rights, :security_classification,
-                                             :issued, :modified, :created, :publisher, :summary, alternative_titles: [],
-                                             creators: [], keywords: [], related_data_resources: [], themes: [])
+                                             :issued, :modified, :created, :publisher, :summary,
+                                             alternative_titles: [], creators: [], keywords: [],
+                                             related_data_resources: [], themes: [])
       end
 
       def handle_bad_request(exception)

--- a/app/forms/data_service_form.rb
+++ b/app/forms/data_service_form.rb
@@ -3,12 +3,12 @@
 class DataServiceForm
   include ActiveModel::Model
 
-  attr_accessor :endpoint_url, :endpoint_description, :serves_data, :service_type, :status, :identifier, :title,
+  attr_accessor :endpoint_url, :endpoint_description, :serves_data, :service_type, :service_status, :identifier, :title,
                 :description, :keywords, :themes, :licence, :version, :contact_name, :contact_email,
                 :alternative_titles, :access_rights, :security_classification, :issued, :modified, :creators,
                 :publisher, :related_data_resources, :summary, :created, :data_service, :data_resource
 
-  validates :endpoint_description, :status, :contact_name, :contact_email, :version, :access_rights,
+  validates :endpoint_description, :service_status, :contact_name, :contact_email, :version, :access_rights,
             :security_classification, :creators, :publisher, :description, :identifier, :licence, :modified,
             :title, presence: true
 
@@ -30,7 +30,7 @@ class DataServiceForm
   private
 
   def build_data_service
-    DataService.new(endpoint_url:, endpoint_description:, serves_data:, service_type:, status:)
+    DataService.new(endpoint_url:, endpoint_description:, serves_data:, service_type:, service_status:)
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/forms/data_service_form.rb
+++ b/app/forms/data_service_form.rb
@@ -44,6 +44,8 @@ class DataServiceForm
   # rubocop:enable Metrics/AbcSize
 
   def _creators
+    return [] if creators.blank?
+
     creators.collect { |slug| Organisation.find_or_create_by(slug:) }
   end
 

--- a/app/models/data_resource.rb
+++ b/app/models/data_resource.rb
@@ -9,5 +9,5 @@ class DataResource < ApplicationRecord
   has_many :related_data_resources, through: :related_resources, class_name: 'DataResource'
 
   enum :access_rights, { INTERNAL: 0, OPEN: 1, COMMERCIAL: 2 }
-  enum :security_classification, { OFFICIAL: 0, OFFICIAL_SENSITIVE: 1, SECRET: 2, TOP_SECRET: 3 }
+  enum :security_classification, { OFFICIAL: 0, SECRET: 1, TOP_SECRET: 2 }
 end

--- a/app/models/data_service.rb
+++ b/app/models/data_service.rb
@@ -6,8 +6,8 @@ class DataService < ApplicationRecord
   has_one :data_resource, as: :resourceable, dependent: :destroy
 
   enum :service_type, { EVENT: 0, REST: 1, SOAP: 2 }
-  enum :status, { ALPHA: 0, BETA: 1, PRIVATE_BETA: 2, PUBLIC_BETA: 3,
-                  PRODUCTION: 4, DEPRECATED: 5, WITHDRAWN: 6 }
+  enum :status, { DISCOVERY: 0, ALPHA: 1, BETA: 2, PRIVATE_BETA: 3,
+                  PUBLIC_BETA: 4, LIVE: 5, DEPRECATED: 6, WITHDRAWN: 7 }
 
   include PgSearch::Model
   pg_search_scope :search,

--- a/app/models/data_service.rb
+++ b/app/models/data_service.rb
@@ -6,8 +6,8 @@ class DataService < ApplicationRecord
   has_one :data_resource, as: :resourceable, dependent: :destroy
 
   enum :service_type, { EVENT: 0, REST: 1, SOAP: 2 }
-  enum :status, { DISCOVERY: 0, ALPHA: 1, BETA: 2, PRIVATE_BETA: 3,
-                  PUBLIC_BETA: 4, LIVE: 5, DEPRECATED: 6, WITHDRAWN: 7 }
+  enum :service_status, { DISCOVERY: 0, ALPHA: 1, BETA: 2, PRIVATE_BETA: 3,
+                          PUBLIC_BETA: 4, LIVE: 5, DEPRECATED: 6, WITHDRAWN: 7 }
 
   include PgSearch::Model
   pg_search_scope :search,

--- a/db/migrate/20230324122753_change_data_service_status_field.rb
+++ b/db/migrate/20230324122753_change_data_service_status_field.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeDataServiceStatusField < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :data_services, :status, :service_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_15_101718) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_24_122753) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -65,7 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_15_101718) do
     t.text "endpoint_description"
     t.text "serves_data", default: [], array: true
     t.integer "service_type"
-    t.integer "status"
+    t.integer "service_status"
     t.index ["organisation_id"], name: "index_data_services_on_organisation_id"
     t.index ["source_id"], name: "index_data_services_on_source_id"
   end

--- a/spec/fixtures/data_service_all_params.json
+++ b/spec/fixtures/data_service_all_params.json
@@ -18,7 +18,7 @@
       "http://example.com/cv/addressLookup"
     ],
     "licence": "https://opensource.org/license/isc-license-txt/",
-    "status": "LIVE",
+    "service_status": "LIVE",
     "version": "2.0.0",
     "access_rights": "INTERNAL",
     "security_classification": "OFFICIAL",

--- a/spec/fixtures/data_service_all_params.json
+++ b/spec/fixtures/data_service_all_params.json
@@ -18,7 +18,7 @@
       "http://example.com/cv/addressLookup"
     ],
     "licence": "https://opensource.org/license/isc-license-txt/",
-    "status": "PRODUCTION",
+    "status": "LIVE",
     "version": "2.0.0",
     "access_rights": "INTERNAL",
     "security_classification": "OFFICIAL",

--- a/spec/fixtures/data_service_required_params.json
+++ b/spec/fixtures/data_service_required_params.json
@@ -15,7 +15,7 @@
       "http://example.com/cv/addressLookup"
     ],
     "licence": "https://opensource.org/license/isc-license-txt/",
-    "status": "PRODUCTION",
+    "status": "LIVE",
     "version": "2.0.0",
     "access_rights": "INTERNAL",
     "security_classification": "OFFICIAL",

--- a/spec/fixtures/data_service_required_params.json
+++ b/spec/fixtures/data_service_required_params.json
@@ -15,7 +15,7 @@
       "http://example.com/cv/addressLookup"
     ],
     "licence": "https://opensource.org/license/isc-license-txt/",
-    "status": "LIVE",
+    "service_status": "LIVE",
     "version": "2.0.0",
     "access_rights": "INTERNAL",
     "security_classification": "OFFICIAL",

--- a/spec/forms/data_service_form_spec.rb
+++ b/spec/forms/data_service_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'DataServiceForm' do
   let(:required_params) do
     {
       endpoint_description: 'Example service',
-      status: 'BETA',
+      service_status: 'BETA',
       contact_name: 'John Doe',
       contact_email: 'john@example.com',
       version: 1,

--- a/spec/forms/data_service_form_spec.rb
+++ b/spec/forms/data_service_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'DataServiceForm' do
       contact_email: 'john@example.com',
       version: 1,
       access_rights: 'OPEN',
-      security_classification: 'OFFICIAL_SENSITIVE',
+      security_classification: 'OFFICIAL',
       creators: organisations.collect(&:slug),
       publisher: organisations.last.slug,
       description: 'Example service',

--- a/spec/requests/api/v1/data_services_spec.rb
+++ b/spec/requests/api/v1/data_services_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'api/v1/data_services' do
 
       response(201, :created) do
         let(:params) do
-          required_params['data_service']['not_a_real_field'] = "abc"
+          required_params['data_service']['not_a_real_field'] = 'abc'
           required_params
         end
 
@@ -94,11 +94,10 @@ RSpec.describe 'api/v1/data_services' do
       end
 
       response(400, :bad_request) do
-        let(:params) { { 'identifier': 'abc' } }
+        let(:params) { { identifier: 'abc' } }
 
         run_test!
       end
-
     end
   end
 end

--- a/spec/requests/api/v1/data_services_spec.rb
+++ b/spec/requests/api/v1/data_services_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe 'api/v1/data_services' do
         run_test!
       end
 
+      response(201, :created) do
+        let(:params) do
+          required_params['data_service']['not_a_real_field'] = "abc"
+          required_params
+        end
+
+        run_test!
+      end
+
       response(422, :unprocessable_entity) do
         let(:params) do
           required_params['data_service'].delete('licence')
@@ -83,6 +92,13 @@ RSpec.describe 'api/v1/data_services' do
 
         run_test!
       end
+
+      response(400, :bad_request) do
+        let(:params) { { 'identifier': 'abc' } }
+
+        run_test!
+      end
+
     end
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -22,6 +22,8 @@ paths:
           description: created
         '422':
           description: unprocessable_entity
+        '400':
+          description: bad_request
       requestBody:
         content:
           application/json:
@@ -31,7 +33,7 @@ paths:
                 data_service:
                   type: object
                   properties:
-                    enpoint_url:
+                    endpoint_url:
                       type: string
                       format: url
                     endpoint_description:
@@ -50,11 +52,12 @@ paths:
                     service_status:
                       type: string
                       enum:
+                      - DISCOVERY
                       - ALPHA
                       - BETA
                       - PRIVATE_BETA
                       - PUBLIC_BETA
-                      - PRODUCTION
+                      - LIVE
                       - DEPRECATED
                       - WITHDRAWN
                     identifier:
@@ -95,7 +98,6 @@ paths:
                       type: string
                       enum:
                       - OFFICIAL
-                      - OFFICIAL_SENSITIVE
                       - SECRET
                       - TOP_SECRET
                     issued:


### PR DESCRIPTION
This PR:
* Renames `status` to `service_status` to match the spec
* Updates the `security_classification` and `service_status` enums to match latest spec
* Handles malformed JSON, missing `data_service` param and unpermitted params slightly more gracefully